### PR TITLE
Add on_delete on ForeignKeys for compatibility with Django >= 2 ?

### DIFF
--- a/generic_confirmation/migrations/0001_initial.py
+++ b/generic_confirmation/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('form_input', generic_confirmation.fields.PickledObjectField(editable=False)),
                 ('form_prefix', models.CharField(max_length=255, null=True, blank=True)),
                 ('object_pk', models.TextField(null=True)),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType', null=True)),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', null=True, on_delete=models.SET_NULL)),
             ],
             options={
             },

--- a/generic_confirmation/migrations/0003_deferredaction_user.py
+++ b/generic_confirmation/migrations/0003_deferredaction_user.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='deferredaction',
             name='user',
-            field=models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.SET_NULL),
             preserve_default=True,
         ),
     ]

--- a/generic_confirmation/models.py
+++ b/generic_confirmation/models.py
@@ -42,12 +42,12 @@ class DeferredAction(models.Model):
     form_input = PickledObjectField(editable=False)
     form_prefix = models.CharField(max_length=255, blank=True, null=True)
 
-    content_type = models.ForeignKey(ContentType, null=True)
+    content_type = models.ForeignKey(ContentType, null=True, on_delete=models.SET_NULL)
     object_pk = models.TextField(null=True)
     instance_object = GenericForeignKey('content_type', 'object_pk')
 
     description = models.TextField(blank=True, null=True)
-    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), blank=True, null=True)
+    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), blank=True, null=True, on_delete=models.SET_NULL)
 
     objects = ConfirmationManager()
 


### PR DESCRIPTION
Hellow,

thank you for your work on this module

I was trying to use this with Django >= 2, and it was complaining that ForeignKeys don't have any on_delete attribute (which is now mandatory)

I've set it to SET_NULL, but honestly I have no idea if that's the right fix :s ...